### PR TITLE
Fix: Accepting pulse counter on GPIO1

### DIFF
--- a/UC500_Series/UC500_Chirpstack.js
+++ b/UC500_Series/UC500_Chirpstack.js
@@ -27,9 +27,14 @@ function Decode(fPort, bytes) {
             decoded.gpio2 = bytes[i + 2] === 0 ? "off" : "on";
             i += 1;
         }
-        // PULSE COUNTER
+        // PULSE COUNTER GPIO1
+        else if (channel_id === 0x03 && channel_type === 0xc8) {
+            decoded.counter1 = readUInt32LE(bytes.slice(i, i + 4));
+            i += 4;
+        }
+        // PULSE COUNTER GPIO2
         else if (channel_id === 0x04 && channel_type === 0xc8) {
-            decoded.counter = readUInt32LE(bytes.slice(i, i + 4));
+            decoded.counter2 = readUInt32LE(bytes.slice(i, i + 4));
             i += 4;
         }
         // ADC 1


### PR DESCRIPTION
The previous decoder accepts only counter on GPIO2, but the UC50x can use both GPIO for counter. The code to read the counter on GPIO was added.