### PR TITLE
Correct firmware channel type for VS121

### DIFF
--- a/VS121/VS121_Chirpstack.js
+++ b/VS121/VS121_Chirpstack.js
@@ -28,7 +28,7 @@ function Decode(fPort, bytes) {
             i += 2;
         }
         // FIRMWARE VERSION
-        else if (channel_id === 0xff && channel_type === 0x0a) {
+        else if (channel_id === 0xff && channel_type === 0x1f) {
             decoded.firmware_version = readVersion(bytes.slice(i, i + 4));
             i += 4;
         }

--- a/VS121/VS121_TTN.js
+++ b/VS121/VS121_TTN.js
@@ -28,7 +28,7 @@ function Decoder(bytes, port) {
             i += 2;
         }
         // FIRMWARE VERSION
-        else if (channel_id === 0xff && channel_type === 0x0a) {
+        else if (channel_id === 0xff && channel_type === 0x1f) {
             decoded.firmware_version = readVersion(bytes.slice(i, i + 4));
             i += 4;
         }


### PR DESCRIPTION
According to https://resource.milesight-iot.com/milesight/document/vs121-user-guide-en.pdf channel type for firmware version is 1f.