### PR TITLE
Add inital Chirpstack V4 decoders

### DIFF
--- a/EM300_Series/EM300-TH/EM300-TH_ChirpstackV4.js
+++ b/EM300_Series/EM300-TH/EM300-TH_ChirpstackV4.js
@@ -1,0 +1,59 @@
+/*
+ * Payload Decoder for Chirpstack and Milesight network server
+ *
+ * Copyright 2021 Milesight IoT
+ * Modified 2022-12-29 Leo Gaggl (leo@opensensing.com) for Chirpstack V4 compliance
+ * 
+ * @product EM300-TH
+ */
+function decodeUplink(input) {
+    let fPort = input.fPort;
+    let bytes = input.bytes;
+    let decoded = {};
+
+    for (let i = 0; i < bytes.length;) {
+        let channel_id = bytes[i++];
+        let channel_type = bytes[i++];
+
+        // BATTERY
+        if (channel_id === 0x01 && channel_type === 0x75) {
+            decoded.battery = bytes[i];
+            i += 1;
+        }
+        // TEMPERATURE
+        else if (channel_id === 0x03 && channel_type === 0x67) {
+            // ℃
+            decoded.temperature = readInt16LE(bytes.slice(i, i + 2)) / 10;
+            i += 2;
+            // ℉
+            // decoded.temperature = readInt16LE(bytes.slice(i, i + 2)) / 10 1.8 + 32;
+            // i +=2;
+        }
+        // HUMIDITY
+        else if (channel_id === 0x04 && channel_type === 0x68) {
+            decoded.humidity = bytes[i] / 2;
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    return {data: decoded};
+}
+
+/* **
+ * bytes to number
+ **/
+function readUInt16LE(bytes) {
+    let value = (bytes[1] << 8) + bytes[0];
+    return value & 0xffff;
+}
+
+function readInt16LE(bytes) {
+    let ref = readUInt16LE(bytes);
+    return ref > 0x7fff ? ref - 0x10000 : ref;
+}
+
+function readInt16LE(bytes) {
+    let ref = readUInt16LE(bytes);
+    return ref > 0x7fff ? ref - 0x10000 : ref;
+}

--- a/EM310_Series/EM310_UDL/EM310-UDL_ChirpstackV4.js
+++ b/EM310_Series/EM310_UDL/EM310-UDL_ChirpstackV4.js
@@ -1,0 +1,50 @@
+/**
+ * Payload Decoder for Chirpstack and Milesight network server
+ * 
+ * Copyright 2021 Milesight IoT
+ * Modified 2022-12-29 Leo Gaggl (leo@opensensing.com) for Chirpstack V4 compliance
+ * 
+ * @product EM310-UDL
+ */
+function decodeUplink(input) {
+    let fPort = input.fPort;
+    let bytes = input.bytes;
+    let decoded = {};
+
+    for (let i = 0; i < bytes.length;) {
+        let channel_id = bytes[i++];
+        let channel_type = bytes[i++];
+        // BATTERY
+        if (channel_id === 0x01 && channel_type === 0x75) {
+            decoded.battery = bytes[i];
+            i += 1;
+        }
+        // DISTANCE
+        else if (channel_id === 0x03 && channel_type === 0x82) {
+            decoded.distance = readUInt16LE(bytes.slice(i, i + 2));
+            i += 2;
+        }
+        // POSITION
+        else if (channel_id === 0x04 && channel_type === 0x00) {
+            decoded.position = bytes[i] === 0 ? "normal" : "tilt";
+            i += 1;
+        } else {
+            break;
+        }
+    }
+
+    return {data: decoded};
+}
+
+/* ******************************************
+ * bytes to number
+ ********************************************/
+function readUInt16LE(bytes) {
+    let value = (bytes[1] << 8) + bytes[0];
+    return value & 0xffff;
+}
+
+function readInt16LE(bytes) {
+    let ref = readUInt16LE(bytes);
+    return ref > 0x7fff ? ref - 0x10000 : ref;
+}

--- a/UC300/UC300-LoRa/UC300_ChirpstackV4.js
+++ b/UC300/UC300-LoRa/UC300_ChirpstackV4.js
@@ -1,74 +1,77 @@
 /**
  * Payload Decoder for Chirpstack and Milesight gateway network server
  *
- * Copyright 2022 Milesight IoTzz
+ * Copyright 2022 Milesight IoT
+ * Modified 2022-12-29 Leo Gaggl (leo@opensensing.com) for Chirpstack V4 compliance
  *
  * @product UC300 series
  */
 
-var gpio_in_chns = [0x03, 0x04, 0x05, 0x06];
-var gpio_out_chns = [0x07, 0x08];
-var pt100_chns = [0x09, 0x0a];
-var ai_chns = [0x0b, 0x0c];
-var av_chns = [0x0d, 0x0e];
+const gpio_in_chns = [0x03, 0x04, 0x05, 0x06];
+const gpio_out_chns = [0x07, 0x08];
+const pt100_chns = [0x09, 0x0a];
+const ai_chns = [0x0b, 0x0c];
+const av_chns = [0x0d, 0x0e];
 
-function Decode(fPort, bytes) {
-    var decoded = {};
+function decodeUplink(input) {
+    let fPort = input.fPort;
+    let bytes = input.bytes;
+    let decoded = {};
 
     for (i = 0; i < bytes.length;) {
-        var channel_id = bytes[i++];
-        var channel_type = bytes[i++];
+        let channel_id = bytes[i++];
+        let channel_type = bytes[i++];
 
         // GPIO Input
         if (includes(gpio_in_chns, channel_id) && channel_type === 0x00) {
-            var id = channel_id - gpio_in_chns[0] + 1;
-            var gpio_in_name = "gpio_in_" + id;
+            let id = channel_id - gpio_in_chns[0] + 1;
+            let gpio_in_name = "gpio_in_" + id;
             decoded[gpio_in_name] = bytes[i] === 0 ? "off" : "on";
             i += 1;
         }
         // GPIO Output
         else if (includes(gpio_out_chns, channel_id) && channel_type === 0x01) {
-            var id = channel_id - gpio_out_chns[0] + 1;
-            var gpio_out_name = "gpio_out_" + id;
+            let id = channel_id - gpio_out_chns[0] + 1;
+            let gpio_out_name = "gpio_out_" + id;
             decoded[gpio_out_name] = bytes[i] === 0 ? "off" : "on";
             i += 1;
         }
         // GPIO AS counter
         else if (includes(gpio_in_chns, channel_id) && channel_type === 0xc8) {
-            var id = channel_id - gpio_in_chns[0] + 1;
-            var counter_name = "counter_" + id;
+            let id = channel_id - gpio_in_chns[0] + 1;
+            let counter_name = "counter_" + id;
             decoded[counter_name] = readUInt32LE(bytes.slice(i, i + 4));
             i += 4;
         }
         // PT100
         else if (includes(pt100_chns, channel_id) && channel_type === 0x67) {
-            var id = channel_id - pt100_chns[0] + 1;
-            var pt100_name = "pt100_" + id;
+            let id = channel_id - pt100_chns[0] + 1;
+            let pt100_name = "pt100_" + id;
             decoded[pt100_name] = readInt16LE(bytes.slice(i, i + 2)) / 10;
             i += 2;
         }
         // ADC CHANNEL
         else if (includes(ai_chns, channel_id) && channel_type === 0x02) {
-            var id = channel_id - ai_chns[0] + 1;
-            var adc_name = "adc_" + id;
+            let id = channel_id - ai_chns[0] + 1;
+            let adc_name = "adc_" + id;
             decoded[adc_name] = readUInt32LE(bytes.slice(i, i + 2)) / 100;
             i += 4;
             continue;
         }
         // ADC CHANNEL for voltage
         else if (includes(av_chns, channel_id) && channel_type === 0x02) {
-            var id = channel_id - av_chns[0] + 1;
-            var adv_name = "adv_" + id;
+            let id = channel_id - av_chns[0] + 1;
+            let adv_name = "adv_" + id;
             decoded[adv_name] = readUInt32LE(bytes.slice(i, i + 2)) / 100;
             i += 4;
             continue;
         }
         // MODBUS
         else if (channel_id === 0xff && channel_type === 0x19) {
-            var modbus_chn_id = bytes[i++] + 1;
-            var data_length = bytes[i++];
-            var data_type = bytes[i++];
-            var chn = "chn" + modbus_chn_id;
+            let modbus_chn_id = bytes[i++] + 1;
+            let data_length = bytes[i++];
+            let data_type = bytes[i++];
+            let chn = "chn" + modbus_chn_id;
             switch (data_type) {
                 case 0:
                     decoded[chn] = bytes[i] ? "on" : "off";
@@ -101,8 +104,8 @@ function Decode(fPort, bytes) {
         }
         // MODBUS READ ERROR
         else if (channel_id === 0xff && channel_type === 0x15) {
-            var modbus_chn_id = bytes[i] + 1;
-            var channel_name = "channel_" + modbus_chn_id + "_error";
+            let modbus_chn_id = bytes[i] + 1;
+            let channel_name = "channel_" + modbus_chn_id + "_error";
             decoded[channel_name] = true;
             i += 1;
         }
@@ -111,7 +114,7 @@ function Decode(fPort, bytes) {
         }
     }
 
-    return decoded;
+    return {data: decoded};
 }
 
 /* ******************************************
@@ -122,44 +125,44 @@ function readUInt8LE(bytes) {
 }
 
 function readInt8LE(bytes) {
-    var ref = readUInt8LE(bytes);
+    let ref = readUInt8LE(bytes);
     return ref > 0x7f ? ref - 0x100 : ref;
 }
 
 function readUInt16LE(bytes) {
-    var value = (bytes[1] << 8) + bytes[0];
+    let value = (bytes[1] << 8) + bytes[0];
     return value & 0xffff;
 }
 
 function readInt16LE(bytes) {
-    var ref = readUInt16LE(bytes);
+    let ref = readUInt16LE(bytes);
     return ref > 0x7fff ? ref - 0x10000 : ref;
 }
 
 function readUInt32LE(bytes) {
-    var value = (bytes[3] << 24) + (bytes[2] << 16) + (bytes[1] << 8) + bytes[0];
+    let value = (bytes[3] << 24) + (bytes[2] << 16) + (bytes[1] << 8) + bytes[0];
     return value & 0xffffffff;
 }
 
 function readInt32LE(bytes) {
-    var ref = readUInt32LE(bytes);
+    let ref = readUInt32LE(bytes);
     return ref > 0x7fffffff ? ref - 0x100000000 : ref;
 }
 
 function readFloatLE(bytes) {
     // JavaScript bitwise operators yield a 32 bits integer, not a float.
     // Assume LSB (least significant byte first).
-    var bits = (bytes[3] << 24) | (bytes[2] << 16) | (bytes[1] << 8) | bytes[0];
-    var sign = bits >>> 31 === 0 ? 1.0 : -1.0;
-    var e = (bits >>> 23) & 0xff;
-    var m = e === 0 ? (bits & 0x7fffff) << 1 : (bits & 0x7fffff) | 0x800000;
-    var f = sign * m * Math.pow(2, e - 150);
+    let bits = (bytes[3] << 24) | (bytes[2] << 16) | (bytes[1] << 8) | bytes[0];
+    let sign = bits >>> 31 === 0 ? 1.0 : -1.0;
+    let e = (bits >>> 23) & 0xff;
+    let m = e === 0 ? (bits & 0x7fffff) << 1 : (bits & 0x7fffff) | 0x800000;
+    let f = sign * m * Math.pow(2, e - 150);
     return f;
 }
 
 function includes(datas, value) {
-    var size = datas.length;
-    for (var i = 0; i < size; i++) {
+    let size = datas.length;
+    for (let i = 0; i < size; i++) {
         if (datas[i] == value) {
             return true;
         }


### PR DESCRIPTION
These are the first Milesight devices we needed to get working on Chirpstack V4.

The current Chirpstack decoders do not work with V4.