### PR TITLE
Declare loop variable

### DIFF
--- a/CT_Series/CT101/CT101_Decoder.js
+++ b/CT_Series/CT101/CT101_Decoder.js
@@ -23,7 +23,7 @@ function Decoder(bytes, port) {
 
 function milesightDeviceDecode(bytes) {
     var decoded = {};
-    for (i = 0; i < bytes.length; ) {
+    for (var i = 0; i < bytes.length; ) {
         var channel_id = bytes[i++];
         var channel_type = bytes[i++];
 


### PR DESCRIPTION
- needed to add the `var` declaration for the loop variable so this decoder doesn't have any problems when run in strict mode.