### PR TITLE
Closes #67

### DIFF
--- a/WTS_series/WTS305&WTS506_Decoder.js
+++ b/WTS_series/WTS305&WTS506_Decoder.js
@@ -63,7 +63,7 @@ function milesightDeviceDecode(bytes) {
             i += 2;
         }
         // rainfall_total, unit mm, Frame counter to define whether device enters the new rainfall accumulation phase, it will plus 1 every upload, range: 0~255
-        else if (channel_id === 0x08 && channel_type === 0x77) {
+        else if (channel_id === 0x08 && channel_type === 0xEC) {
             decoded.rainfall_total = readUInt16LE(bytes.slice(i, i + 2)) / 100;
             decoded.rainfall_counter = bytes[i + 2];
             i += 3;


### PR DESCRIPTION
The rainfall parsing is filtering the wrong channel. The right one is 0xEC, as defined in the milesight documentation.