### PR TITLE
Bug Fix: GS601 Encoder Issue

### DIFF
--- a/GS_Series/GS601/GS601_Encoder.js
+++ b/GS_Series/GS601/GS601_Encoder.js
@@ -532,8 +532,8 @@ function setVapingIndexAlarmSettings(vaping_index_alarm_settings) {
     buffer.writeUInt8(0x6e);
     buffer.writeUInt8(getValue(enable_map, enable));
     buffer.writeUInt8(getValue(threshold_condition_map, threshold_condition));
-    buffer.writeInt16LE(threshold_min);
-    buffer.writeInt16LE(threshold_max);
+    buffer.writeUInt8(threshold_min);
+    buffer.writeUInt8(threshold_max);
     return buffer.toBytes();
 }
 


### PR DESCRIPTION
## Bug Fix: GS601 Encoder Issue

**Problem:**
The GS601 encoder was incorrectly encoding vaping index alarm threshold min/max values as UInt16, when the *7.3DownlinkCommands* section in the [user guide](https://resource.milesight.com/milesight/iot/document/gs601-user-guide-en.pdf), indicates these values should be encoded as UInt8.

**Solution:**
Changed `writeUInt16` to `writeUInt8` for:
- `vaping_index_alarm_settings.threshold_min`
- `vaping_index_alarm_settings.threshold_max`

**Files Changed:**
- `GS_Series/GS601/GS601_Encoder.js`

**Note:** Only the source file has been modified; the _pack version may need regeneration.