### PR TITLE
sync: mirror codec release v1.5.38 to SensorDecoders main

### DIFF
--- a/em-series/em500-swl/em500-swl-decoder.js
+++ b/em-series/em500-swl/em500-swl-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product EM500-SWL
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */

--- a/em-series/em500-swl/em500-swl-encoder.js
+++ b/em-series/em500-swl/em500-swl-encoder.js
@@ -5,7 +5,7 @@
  *
  * @product EM500-SWL
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */


### PR DESCRIPTION
## Summary

- Codec version: `v1.5.38`
- Source branch: `release`
- Source commit: `b4b9a3f892813af5af3a3661ba79dbfe6b977a9d`
- Delta range: `v1.5.37 .. v1.5.38`

## Mirrored files

- `em-series/em500-swl/em500-swl-decoder.js`
- `em-series/em500-swl/em500-swl-encoder.js`
