### PR TITLE
fix: 'getValue' function name collision in em300-th

### DIFF
--- a/em-series/em300-th/em300-th-decoder.js
+++ b/em-series/em300-th/em300-th-decoder.js
@@ -242,42 +242,42 @@ function readLoRaWANClass(type) {
         2: "Class C",
         3: "Class CtoB",
     };
-    return getValue(class_map, type);
+    return getValueByKey(class_map, type);
 }
 
 function readResetEvent(status) {
     var status_map = { 0: "normal", 1: "reset" };
-    return getValue(status_map, status);
+    return getValueByKey(status_map, status);
 }
 
 function readDeviceStatus(status) {
     var status_map = { 0: "off", 1: "on" };
-    return getValue(status_map, status);
+    return getValueByKey(status_map, status);
 }
 
 function readYesNoStatus(status) {
     var status_map = { 0: "no", 1: "yes" };
-    return getValue(status_map, status);
+    return getValueByKey(status_map, status);
 }
 
 function readEnableStatus(status) {
     var status_map = { 0: "disable", 1: "enable" };
-    return getValue(status_map, status);
+    return getValueByKey(status_map, status);
 }
 
 function readConditionType(condition) {
     var condition_map = { 0: "disable", 1: "below", 2: "above", 3: "between", 4: "outside" };
-    return getValue(condition_map, condition);
+    return getValueByKey(condition_map, condition);
 }
 
 function readD2DMode(mode) {
     var mode_map = { 1: "temperature_alarm", 2: "temperature_alarm_release" };
-    return getValue(mode_map, mode);
+    return getValueByKey(mode_map, mode);
 }
 
 function readD2DReportType(type) {
     var type_map = { 0: "lora", 1: "d2d", 3: "d2d_and_lora" };
-    return getValue(type_map, type);
+    return getValueByKey(type_map, type);
 }
 
 /* eslint-disable */
@@ -309,7 +309,7 @@ function readD2DCommand(bytes) {
     return ("0" + (bytes[1] & 0xff).toString(16)).slice(-2) + ("0" + (bytes[0] & 0xff).toString(16)).slice(-2);
 }
 
-function getValue(map, key) {
+function getValueByKey(map, key) {
     if (RAW_VALUE) return key;
 
     var value = map[key];


### PR DESCRIPTION
This PR addresses the issue reported in #72, but only for EM300-TH, which is the device I'm using.

If this is the proper fix, it should be applied to other devices too.

Sending this for feedback, and as a hint to other impacted users.

The OP in #72 suggests to rename that function in the encoder script. I did it in the decoded script. I don't think it matters. I did it this way because the encoder script has a `getValues` function (plural) that I would have been tempted to rename too, making for a wider changer.

Testing this right now and it does the job. Before this change, I would get this error:

```
level:"ERROR"
code:"UPLINK_CODEC"
description:"JS error: Error: invalid redefinition of global identifier in module code at main:825:12 "
```

so unlike what is written in #72, the code wouldn't even be executed at all.