### PR TITLE
fix(ws523): don't fail whole uplink decode on unknown downlink response

### DIFF
--- a/ws-series/ws523/ws523-decoder.js
+++ b/ws-series/ws523/ws523-decoder.js
@@ -178,7 +178,10 @@ function handle_downlink_response(channel_type, bytes, offset) {
             offset += 2;
             break;
         default:
-            throw new Error("unknown downlink response");
+            // unknown response type: length is unknown, so stop parsing
+            // instead of throwing and losing all fields decoded so far
+            offset = bytes.length;
+            break;
     }
 
     return { data: decoded, offset: offset };


### PR DESCRIPTION
**Problem**
handle_downlink_response throws Error("unknown downlink response") in its default case. Because it is called from milesightDeviceDecode, a single unrecognized 0xfe/0xff response type aborts decoding of the entire frame. On ChirpStack v4 this shows up as an UPLINK_CODEC error and all fields already decoded from the same frame are lost:


```
level:"ERROR" code:"UPLINK_CODEC"
description:"JS error: Error: unknown downlink response at handle_downlink_response (eval_script:182:23) ..."
Observed in production with a WS523-16A-EU (Class C, EU868).
```

**Fix**
The length of an unknown response type is not known, so the remaining bytes cannot be parsed safely. Stop parsing there and return the fields decoded so far, instead of throwing. This matches the main decode loop, which already breaks silently on unknown channels.