### PR TITLE
sync: mirror codec release v1.5.53 to SensorDecoders main

### DIFF
--- a/am-series/am307/am307-decoder.js
+++ b/am-series/am307/am307-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM307(v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am307l/am307l-decoder.js
+++ b/am-series/am307l/am307l-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM307L(v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am308/am308-decoder.js
+++ b/am-series/am308/am308-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM308(v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am308l/am308l-decoder.js
+++ b/am-series/am308l/am308l-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM308L(v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am319-hcho-ir/am319-hcho-ir-decoder.js
+++ b/am-series/am319-hcho-ir/am319-hcho-ir-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM319 HCHO (v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am319-hcho/am319-hcho-decoder.js
+++ b/am-series/am319-hcho/am319-hcho-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM319 HCHO (v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am319-o3/am319-o3-decoder.js
+++ b/am-series/am319-o3/am319-o3-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM319 O3 (v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am319l-hcho-ir/am319l-hcho-ir-decoder.js
+++ b/am-series/am319l-hcho-ir/am319l-hcho-ir-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM319 HCHO (v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/am-series/am319l-o3/am319l-o3-decoder.js
+++ b/am-series/am319l-o3/am319l-o3-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product AM319 O3 (v2)
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/ds-series/ds3604/ds3604-codec.json
+++ b/ds-series/ds3604/ds3604-codec.json
@@ -167,7 +167,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -180,7 +180,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -193,7 +193,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -206,7 +206,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -219,7 +219,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -232,7 +232,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -245,7 +245,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -258,7 +258,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -271,7 +271,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -284,7 +284,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -297,7 +297,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -310,7 +310,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -323,7 +323,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -336,7 +336,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -349,7 +349,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -362,7 +362,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -375,7 +375,7 @@
             "access_mode": "R",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -388,7 +388,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -401,7 +401,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -414,7 +414,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -427,7 +427,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"
@@ -440,7 +440,7 @@
             "access_mode": "RW",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"

--- a/em-series/em320-th-v2/em320-th-v2-decoder.js
+++ b/em-series/em320-th-v2/em320-th-v2-decoder.js
@@ -70,7 +70,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
 

--- a/uc-series/uc100-v2/uc100-v2-codec.json
+++ b/uc-series/uc100-v2/uc100-v2-codec.json
@@ -1661,7 +1661,7 @@
             "access_mode": "R",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"

--- a/uc-series/uc100/uc100-codec.json
+++ b/uc-series/uc100/uc100-codec.json
@@ -509,7 +509,7 @@
             "access_mode": "R",
             "data_type": "TEXT",
             "value_type": "STRING",
-            "max_length": 255,
+            "max_length": 242,
             "bacnet_type": "character_string_value_object",
             "bacnet_unit_type_id": 95,
             "bacnet_unit_type": "UNITS_NO_UNITS"

--- a/vs-series/vs373/vs373-decoder.js
+++ b/vs-series/vs373/vs373-decoder.js
@@ -5,7 +5,7 @@
  *
  * @product VS373
  */
-var RAW_VALUE = 0x00;
+var RAW_VALUE = 0x01;
 
 /* eslint no-redeclare: "off" */
 /* eslint-disable */
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS


### PR DESCRIPTION
## Summary

- Codec version: `v1.5.53`
- Source branch: `release`
- Source commit: `c912bb619a4ad9046dad75e99e68f0efe8628f73`
- Delta range: `v1.5.52 .. v1.5.53`

## Mirrored files

- `am-series/am307/am307-decoder.js`
- `am-series/am307l/am307l-decoder.js`
- `am-series/am308/am308-decoder.js`
- `am-series/am308l/am308l-decoder.js`
- `am-series/am319-hcho-ir/am319-hcho-ir-decoder.js`
- `am-series/am319-hcho/am319-hcho-decoder.js`
- `am-series/am319-o3/am319-o3-decoder.js`
- `am-series/am319l-hcho-ir/am319l-hcho-ir-decoder.js`
- `am-series/am319l-o3/am319l-o3-decoder.js`
- `ds-series/ds3604/ds3604-codec.json`
- `em-series/em320-th-v2/em320-th-v2-decoder.js`
- `uc-series/uc100-v2/uc100-v2-codec.json`
- `uc-series/uc100/uc100-codec.json`
- `vs-series/vs373/vs373-decoder.js`
