### PR TITLE
fix: pass fixed status to device status decoder for consistency

### DIFF
--- a/am-series/am319-hcho-well/am319-hcho-well-decoder.js
+++ b/am-series/am319-hcho-well/am319-hcho-well-decoder.js
@@ -50,7 +50,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
         // LORAWAN CLASS

--- a/em-series/em320-th-v2/em320-th-decoder.js
+++ b/em-series/em320-th-v2/em320-th-decoder.js
@@ -70,7 +70,7 @@ function milesightDeviceDecode(bytes) {
         }
         // DEVICE STATUS
         else if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = readDeviceStatus(bytes[i]);
+            decoded.device_status = readDeviceStatus(1);
             i += 1;
         }
 

--- a/em-series/em410-rdl/em410-rdl-cellular.js
+++ b/em-series/em410-rdl/em410-rdl-cellular.js
@@ -38,7 +38,7 @@ function milesightDeviceDecode(bytes) {
 
         // DEVICE STATUS
         if (channel_id === 0xff && channel_type === 0x0b) {
-            decoded.device_status = bytes[i];
+            decoded.device_status = readOnOffStatus(1);
             i += 1;
         }
         // IPSO VERSION
@@ -436,6 +436,17 @@ function readLoRaWANClass(type) {
             return "ClassC";
         case 3:
             return "ClassCtoB";
+    }
+}
+
+function readOnOffStatus(status) {
+    switch (status) {
+        case 0:
+            return "off";
+        case 1:
+            return "on";
+        default:
+            return "Unknown";
     }
 }
 


### PR DESCRIPTION
Align device status channel (0xff, 0x0b) parsing with the common decoder style: report online/on instead of echoing the raw reported value, which decoded to unknown when devices send 0xff.